### PR TITLE
Add PlatformIO config and firmware README (Issue #38)

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -1,0 +1,31 @@
+# Firmware ESP-IDF — Heltec LoRa32 V3 ESP32-S3
+
+This folder contains the ESP32 sensor node firmware for TripoliLabs Air Quality Monitoring.
+
+## Requirements
+
+- VS Code + PlatformIO extension
+- Heltec LoRa32 V3 ESP32-S3
+- USB data cable
+
+## Build
+
+From the repository root:
+
+```bash
+# Build the firmware (default env: heltec_lora32_v3_debug)
+pio run -d firmware
+
+# Build release version
+pio run -d firmware -e heltec_lora32_v3_release
+
+# Flash (USB). Build debug if needed, then flash to the connected board
+pio run -d firmware -e heltec_lora32_v3_debug -t upload
+
+# Flash with explicit port (COM? in Windows)
+pio run -d firmware -e heltec_lora32_v3_debug -t upload --upload-port <PORT>
+
+# Serial monitor (Connect to the board’s serial output and show ESP-IDF logs)
+pio device monitor -d firmware -e heltec_lora32_v3_debug
+
+```

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -3,10 +3,11 @@
 This folder contains the ESP32 sensor node firmware for TripoliLabs Air Quality Monitoring.
 
 ## Requirements
-
-- VS Code + PlatformIO extension
+- python 3.12 version
+- pip 26.0.1 version
+- VS Code + PlatformIO extension (pio CLI)
 - Heltec LoRa32 V3 ESP32-S3
-- USB data cable
+- USB data cable (In case of flashing)
 
 ## Build
 
@@ -19,6 +20,11 @@ pio run -d firmware
 # Build release version
 pio run -d firmware -e heltec_lora32_v3_release
 
+```
+
+"After Build the firmware a sdkconfig.heltec_lora32_v3_debug file will be created automatically, Be sure that CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y is 8MB not 2M"
+
+```bash
 # Flash (USB). Build debug if needed, then flash to the connected board
 pio run -d firmware -e heltec_lora32_v3_debug -t upload
 

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -18,10 +18,11 @@ upload_protocol = esptool
 upload_speed = 921600
 
 ; Library dependencies
+lib_compat_mode = off
 lib_deps =
-  mcci-catena/MCCI LoRaWAN LMIC library
-  adafruit/Adafruit BME280 Library
-
+    https://github.com/boschsensortec/BME280_SensorAPI.git
+    jgromes/RadioLib@^7.5.0
+    
 [env:heltec_lora32_v3_debug]
 extends = env:heltec_lora32_v3
 build_type = debug

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -1,32 +1,31 @@
 ; PlatformIO Project Configuration File
-; Air Quality Monitoring Node - LILYGO T-Beam V1.2
-; https://docs.platformio.org/page/projectconf.html
+; TripoliLabs Air Quality Monitoring - Firmware
+; Target: Heltec LoRa32 V3 ESP32-S3
 
-[env:tbeam-v12]
+[platformio]
+default_envs = heltec_lora32_v3_debug
+
+[env:heltec_lora32_v3]
 platform = espressif32
-board = ttgo-t-beam
+board = heltec_wifi_lora_32_V3
 framework = espidf
+
+; Serial monitor
 monitor_speed = 115200
 
-; ESP-IDF specific settings
-board_build.partitions = partitions.csv
-
-; Build flags
-build_flags =
-    -DCORE_DEBUG_LEVEL=3
-    -DBOARD_HAS_PSRAM
-    -DLILYGO_TBEAM_V1_2
+; Upload over USB
+upload_protocol = esptool
+upload_speed = 921600
 
 ; Library dependencies
 lib_deps =
-    ; LoRaWAN stack
-    ; PM sensor driver
-    ; BME280 driver
+  mcci-catena/MCCI LoRaWAN LMIC library
+  adafruit/Adafruit BME280 Library
 
-; Upload settings
-upload_speed = 921600
+[env:heltec_lora32_v3_debug]
+extends = env:heltec_lora32_v3
+build_type = debug
 
-; Monitor filters
-monitor_filters =
-    esp32_exception_decoder
-    time
+[env:heltec_lora32_v3_release]
+extends = env:heltec_lora32_v3
+build_type = release


### PR DESCRIPTION
## Closes
Fixes #38

## Type of Change
- [x] `chore` - Maintenance
- [x] `docs` - Documentation

## Summary
- Add PlatformIO configuration for Heltec LoRa32 V3 (ESP32-S3) using ESP-IDF
- Add firmware README with build / release build / USB flash / serial monitor commands

## How to test
```bash
# Build (default debug)
pio run -d firmware

# Build release
pio run -d firmware -e heltec_lora32_v3_release

# Flash (USB)
pio run -d firmware -e heltec_lora32_v3_debug -t upload

# Serial monitor
pio device monitor -d firmware -e heltec_lora32_v3_debug
